### PR TITLE
loadBannerAd looping because of autoRefresh

### DIFF
--- a/java/advanced/BannerRecyclerViewExample/app/src/main/java/com/google/android/gms/example/bannerrecyclerviewexample/MainActivity.java
+++ b/java/advanced/BannerRecyclerViewExample/app/src/main/java/com/google/android/gms/example/bannerrecyclerviewexample/MainActivity.java
@@ -149,6 +149,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onAdLoaded() {
                 super.onAdLoaded();
+                adView.setAdListener(null);
                 // The previous banner ad loaded successfully, call this method again to
                 // load the next ad in the items list.
                 loadBannerAd(index + ITEMS_PER_AD);
@@ -156,6 +157,7 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onAdFailedToLoad(int errorCode) {
+                adView.setAdListener(null);
                 // The previous banner ad failed to load. Call this method again to load
                 // the next ad in the items list.
                 Log.e("MainActivity", "The previous banner ad failed to load. Attempting to"


### PR DESCRIPTION
Will be called `onAdLoaded()` or `onAdFailedToLoad(int errorCode)` of AdListener when AdMob's autoRefresh do. 
So I guess that we should make AdListener into `null` on first callback.

## Current
<img width="1352" alt="スクリーンショット 2019-12-03 14 56 57" src="https://user-images.githubusercontent.com/27717556/70024671-2374c680-15de-11ea-94ee-52fa4fab55ee.png">

## Improved
<img width="1357" alt="スクリーンショット 2019-12-03 14 55 01" src="https://user-images.githubusercontent.com/27717556/70024696-3091b580-15de-11ea-952b-520ac7c9c3cf.png">

I want to know whether we should refresh all adList or refresh only visible ad when auto refreshing any ad.
Or do you have some better solutions? ex. On `RecyclerView's viewHolder.onBindViewHolder`, start loading and prefetch next indexed ad. ([my sample](https://github.com/FujiKinaga/AdMobSample))

Could you please give me some feedbacks!🙇‍♂️
