### PR TITLE
In Android 11 two methods are deprecated

### DIFF
--- a/kotlin/admob/AdaptiveBannerExample/app/src/main/java/com/google/android/gms/example/adaptivebannerexample/MyActivity.kt
+++ b/kotlin/admob/AdaptiveBannerExample/app/src/main/java/com/google/android/gms/example/adaptivebannerexample/MyActivity.kt
@@ -33,9 +33,7 @@ class MyActivity : AppCompatActivity() {
   // If the ad hasn't been laid out, default to the full screen width.
   private val adSize: AdSize
     get() {
-      val display = windowManager.defaultDisplay
-      val outMetrics = DisplayMetrics()
-      display.getMetrics(outMetrics)
+      val outMetrics = resources.displayMetrics
 
       val density = outMetrics.density
 


### PR DESCRIPTION
'getter for defaultDisplay: Display!' is deprecated.
and
'getMetrics(DisplayMetrics!): Unit' is deprecated.