### PR TITLE
Fixed issue #689: Lateinit property appOpenAdManager has not been assigned

### DIFF
--- a/kotlin/admob/AppOpenExample/app/src/main/java/com/google/android/gms/example/appopenexample/MyApplication.kt
+++ b/kotlin/admob/AppOpenExample/app/src/main/java/com/google/android/gms/example/appopenexample/MyApplication.kt
@@ -28,8 +28,8 @@ class MyApplication :
   private lateinit var appOpenAdManager: AppOpenAdManager
   private var currentActivity: Activity? = null
 
-  override fun onCreate(owner: LifecycleOwner) {
-    super<DefaultLifecycleObserver>.onCreate(owner)
+  override fun onCreate() {
+    super<MultiDexApplication>.onCreate()
     registerActivityLifecycleCallbacks(this)
 
     ProcessLifecycleOwner.get().lifecycle.addObserver(this)


### PR DESCRIPTION
Application.onCreate() needs to be overridden to initialize appOpenAdManager on app start.